### PR TITLE
Support comma-separated months

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -15,4 +15,4 @@ Originally created by Ben Davis at https://github.com/ben-davis/prettycron .
 Contributors
 ------------
 
-None yet. Why not be the first?
+* MIke Readhead <github@0xdb.co.uk>

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -15,4 +15,4 @@ Originally created by Ben Davis at https://github.com/ben-davis/prettycron .
 Contributors
 ------------
 
-* MIke Readhead <github@0xdb.co.uk>
+* Mike Readhead <github@0xdb.co.uk>

--- a/pretty_cron/api.py
+++ b/pretty_cron/api.py
@@ -39,8 +39,6 @@ def _pretty_date(month_day, month, week_day):
 
         if month != '*' and not (type(month)==tuple):
             pretty_date += " in {0}".format(_human_month(month))
-        elif type(month)==tuple:
-            print("DANGER")
     else:
         if month_day != "*":
             month_day_date = "on the {0}".format(_ordinal(month_day))
@@ -55,8 +53,6 @@ def _pretty_date(month_day, month, week_day):
         if month_day_date:
             if month != '*' and not (type(month)==tuple):
                 month_day_date += " of {0}".format(_human_month(month))
-            elif type(month)==tuple:
-                print("DANGER")
             else:
                 month_day_date += " of every month"
 
@@ -76,7 +72,10 @@ def _pretty_date(month_day, month, week_day):
 def _human_month(month):
     if type(month)==tuple:
         months = [datetime.date(2014, m, 1).strftime("%B") for m in month]
-        return " and ".join(months)
+        *rest, last, two = months
+        if rest:
+            return ", ".join(rest) + ", {} and {}".format(last, two)
+        return "{} and {}".format(last, two)
     return datetime.date(2014, month, 1).strftime("%B")
 
 

--- a/pretty_cron/api.py
+++ b/pretty_cron/api.py
@@ -4,21 +4,26 @@ import datetime
 def prettify_cron(expression):
     pieces = []
     for piece in expression.split(" "):
-        if piece != "*":
+        if piece != "*" and "," not in piece:
             try:
                 piece = int(piece)
             except ValueError:
                 # */2 and other cron expressions aren't supported yet - return
                 # as-is
                 return expression
+        elif "," in piece:
+            splitter = piece.split(",")
+            try:
+                splitter = [int(p) for p in splitter]
+            except ValueError:
+                return expression
+            piece = tuple(splitter)
         pieces.append(piece)
-
     try:
         minute, hour, month_day, month, week_day = pieces
     except ValueError:
         # More or fewer pieces than expected - return as-is
         return expression
-
     date = _pretty_date(month_day, month, week_day)
     time = _pretty_time(minute, hour)
 
@@ -32,8 +37,10 @@ def _pretty_date(month_day, month, week_day):
     if month_day == "*" and week_day == "*":
         pretty_date = "every day"
 
-        if month != '*':
+        if month != '*' and not (type(month)==tuple):
             pretty_date += " in {0}".format(_human_month(month))
+        elif type(month)==tuple:
+            print("DANGER")
     else:
         if month_day != "*":
             month_day_date = "on the {0}".format(_ordinal(month_day))
@@ -46,8 +53,10 @@ def _pretty_date(month_day, month, week_day):
             week_day_date = ""
 
         if month_day_date:
-            if month != "*":
+            if month != '*' and not (type(month)==tuple):
                 month_day_date += " of {0}".format(_human_month(month))
+            elif type(month)==tuple:
+                print("DANGER")
             else:
                 month_day_date += " of every month"
 
@@ -65,6 +74,9 @@ def _pretty_date(month_day, month, week_day):
 
 
 def _human_month(month):
+    if type(month)==tuple:
+        months = [datetime.date(2014, m, 1).strftime("%B") for m in month]
+        return " and ".join(months)
     return datetime.date(2014, month, 1).strftime("%B")
 
 

--- a/pretty_cron/api.py
+++ b/pretty_cron/api.py
@@ -51,7 +51,7 @@ def _pretty_date(month_day, month, week_day):
             week_day_date = ""
 
         if month_day_date:
-            if month != '*' and not (type(month)==tuple):
+            if month != '*':
                 month_day_date += " of {0}".format(_human_month(month))
             else:
                 month_day_date += " of every month"

--- a/pretty_cron/api.py
+++ b/pretty_cron/api.py
@@ -70,7 +70,7 @@ def _pretty_date(month_day, month, week_day):
 
 
 def _human_month(month):
-    if type(month)==tuple:
+    if isinstance(month, tuple):
         months = [datetime.date(2014, m, 1).strftime("%B") for m in month]
         rest, last, two = months[:-2],months[-2],months[-1]
         if rest:

--- a/pretty_cron/api.py
+++ b/pretty_cron/api.py
@@ -72,7 +72,7 @@ def _pretty_date(month_day, month, week_day):
 def _human_month(month):
     if type(month)==tuple:
         months = [datetime.date(2014, m, 1).strftime("%B") for m in month]
-        *rest, last, two = months
+        rest, last, two = months[:-2],months[-2],months[-1]
         if rest:
             return ", ".join(rest) + ", {} and {}".format(last, two)
         return "{} and {}".format(last, two)

--- a/pretty_cron/api.py
+++ b/pretty_cron/api.py
@@ -37,7 +37,7 @@ def _pretty_date(month_day, month, week_day):
     if month_day == "*" and week_day == "*":
         pretty_date = "every day"
 
-        if month != '*' and not (type(month)==tuple):
+        if month != '*':
             pretty_date += " in {0}".format(_human_month(month))
     else:
         if month_day != "*":

--- a/tests/test_prettify.py
+++ b/tests/test_prettify.py
@@ -46,6 +46,18 @@ class PrettyCronTest(unittest.TestCase):
             "At 00:00 on the 1st of January and on every Monday in January"
         )
 
+    def test_every_specific_day_in_months_and_weekly(self):
+        assert (
+            pc("0 0 1 1,2 1") ==
+            "At 00:00 on the 1st of January and February and on every Monday in January and February"
+        )
+
+    def test_every_specific_day_in_months_and_more_and_weekly(self):
+        assert (
+            pc("0 0 1 1,2,3 1") ==
+            "At 00:00 on the 1st of January, February and March and on every Monday in January, February and March"
+        )
+
     def test_daily(self):
         assert pc("0 0 * * *") == "At 00:00 every day"
 

--- a/tests/test_prettify.py
+++ b/tests/test_prettify.py
@@ -22,6 +22,9 @@ class PrettyCronTest(unittest.TestCase):
     def test_every_day_in_month(self):
         assert pc("12 15 * 1 *") == "At 15:12 every day in January"
 
+    def test_every_day_in_months(self):
+        assert pc("12 15 * 1,12 *") == "At 15:12 every day in January and December"
+
     def test_every_specific_day_in_month(self):
         assert pc("0 0 * 1 1") == "At 00:00 on every Monday in January"
 

--- a/tests/test_prettify.py
+++ b/tests/test_prettify.py
@@ -25,6 +25,9 @@ class PrettyCronTest(unittest.TestCase):
     def test_every_specific_day_in_month(self):
         assert pc("0 0 * 1 1") == "At 00:00 on every Monday in January"
 
+    def test_every_specific_day_in_months(self):
+        assert pc("0 0 * 1,2 1") == "At 00:00 on every Monday in January and February"
+
     def test_weekly(self):
         assert pc("0 0 * * 0") == "At 00:00 every Sunday"
 

--- a/tests/test_prettify.py
+++ b/tests/test_prettify.py
@@ -28,6 +28,9 @@ class PrettyCronTest(unittest.TestCase):
     def test_every_specific_day_in_months(self):
         assert pc("0 0 * 1,2 1") == "At 00:00 on every Monday in January and February"
 
+    def test_every_specific_day_in_months_and_then_more(self):
+        assert pc("0 0 * 1,2,4,5 1") == "At 00:00 on every Monday in January, February, April and May"
+
     def test_weekly(self):
         assert pc("0 0 * * 0") == "At 00:00 every Sunday"
 


### PR DESCRIPTION
Hello,

Fair warning, this is my first pull request.

I'm using pretty cron and noticed it can't handle special characters yet.

For the project we're using it on, we don't need any others apart form commas (in months), so I thought I'd add support. 

There's a few tests for the changes and I've broken support for python 2,  as it won't affect me. 

I'll have a look at making it python 2 compatible as well if you want/need. 
