### PR TITLE
Add full test script with all the modern tools, fixes for Python 2/3 unicode compatibility

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+charset = utf-8
+end_of_line = lf
+
+[*.py]
+line_length = 120
+
+[*.bat]
+indent_style = tab
+end_of_line = crlf
+
+[LICENSE]
+insert_final_newline = false
+
+[Makefile]
+indent_style = tab

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ Pending Release
 ---------------
 
 * New release notes here
+* Now always returns ``unicode`` on Python 2 for consistency.
 
 1.0.2 (2016-05-03)
 ------------------

--- a/pretty_cron/__init__.py
+++ b/pretty_cron/__init__.py
@@ -1,3 +1,6 @@
+# -*- encoding:utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 from .api import prettify_cron  # noqa
 
 __author__ = 'Adam Johnson'

--- a/pretty_cron/api.py
+++ b/pretty_cron/api.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import datetime
 
 
@@ -38,7 +40,7 @@ def prettify_cron(expression):
     time = _pretty_time(minute, hour)
 
     return " ".join(
-        filter(None, (time, date))
+        x for x in (time, date) if x
     )
 
 
@@ -72,7 +74,7 @@ def _pretty_date(month_day, month, week_day):
             )
 
         pretty_date = " and ".join(
-            filter(None, (month_day_date, week_day_date))
+            x for x in (month_day_date, week_day_date) if x
         )
 
     return pretty_date

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,10 @@
-coverage
+docutils==0.12
+flake8==2.5.4
+isort==4.2.5
+modernize==0.5
+pep8==1.7.0
+py==1.4.31
+pyflakes==1.1.0
+Pygments==2.1.3
 pytest==2.9.1
-twine
-wheel
+six==1.10.0

--- a/runtests.py
+++ b/runtests.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import subprocess
+import sys
+
+import pytest
+from flake8.main import main as flake8_main
+from libmodernize.main import main as libmodernize_main
+
+
+CODE_PATHS = [
+    'setup.py',
+    'runtests.py',
+    'pretty_cron',
+    'tests',
+]
+
+
+def main():
+    try:
+        sys.argv.remove('--nolint')
+    except ValueError:
+        run_lint = True
+    else:
+        run_lint = False
+
+    try:
+        sys.argv.remove('--lintonly')
+    except ValueError:
+        run_tests = True
+    else:
+        run_tests = False
+
+    if run_tests:
+        exit_on_failure(tests_main())
+
+    if run_lint:
+        exit_on_failure(run_flake8())
+        exit_on_failure(run_modernize())
+        exit_on_failure(run_isort())
+
+        # Broken on 2.7.9 due to http://bugs.python.org/issue23063
+        if sys.version_info[:3] != (2, 7, 9):
+            exit_on_failure(run_setup_py_check())
+
+
+def tests_main():
+    return pytest.main()
+
+
+def run_flake8():
+    print('Running flake8 code linting')
+    try:
+        original_argv = sys.argv
+        sys.argv = ['flake8'] + CODE_PATHS
+        did_fail = False
+        flake8_main()
+    except SystemExit:
+        did_fail = True
+    finally:
+        sys.argv = original_argv
+
+    print('flake8 failed' if did_fail else 'flake8 passed')
+    return did_fail
+
+
+def run_modernize():
+    print('Running modernize checks')
+    ret = libmodernize_main(CODE_PATHS)
+    print('libmodernize failed' if ret else 'libmodernize passed')
+    return ret
+
+
+def run_isort():
+    print('Running isort check')
+    return subprocess.call([
+        'isort', '--recursive', '--check-only', '--diff',
+        '-a', 'from __future__ import absolute_import, division',
+        '-a', 'from __future__ import print_function, unicode_literals',
+    ] + CODE_PATHS)
+
+
+def run_setup_py_check():
+    print('Running setup.py check')
+    return subprocess.call([
+        'python', 'setup.py', 'check',
+        '-s', '--restructuredtext', '--metadata'
+    ])
+
+
+def exit_on_failure(ret, message=None):
+    if ret:
+        sys.exit(ret)
+
+
+if __name__ == '__main__':
+    main()

--- a/runtests.py
+++ b/runtests.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 
 import pytest
+import six
 from flake8.main import main as flake8_main
 from libmodernize.main import main as libmodernize_main
 
@@ -68,8 +69,19 @@ def run_flake8():
 
 def run_modernize():
     print('Running modernize checks')
-    ret = libmodernize_main(CODE_PATHS)
-    print('libmodernize failed' if ret else 'libmodernize passed')
+    try:
+        orig_stdout = getattr(sys, 'stdout')
+        out = six.StringIO()
+        setattr(sys, 'stdout', out)
+        libmodernize_main([
+            '-x', 'lib2to3.fixes.fix_has_key'
+        ] + CODE_PATHS)
+    finally:
+        sys.stdout = orig_stdout
+    output = out.getvalue()
+    print(output)
+    ret = len(output)
+    print('modernize failed' if ret else 'modernize passed')
     return ret
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,9 @@
 [bdist_wheel]
 universal = 1
+
+[flake8]
+max-line-length = 120
+
+[isort]
+multi_line_output = 5
+not_skip = __init__.py

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import os
 import re
 import sys
 
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
+from setuptools import find_packages, setup
 
 
 def get_version(package):
@@ -16,15 +15,6 @@ def get_version(package):
     """
     init_py = open(os.path.join(package, '__init__.py')).read()
     return re.search("__version__ = ['\"]([^'\"]+)['\"]", init_py).group(1)
-
-
-def get_packages(package):
-    """
-    Return root package and all sub-packages.
-    """
-    return [dirpath
-            for dirpath, dirnames, filenames in os.walk(package)
-            if os.path.exists(os.path.join(dirpath, '__init__.py'))]
 
 
 version = get_version('pretty_cron')
@@ -57,7 +47,7 @@ setup(
     author="Adam Johnson",
     author_email='me@adamj.eu',
     url='https://github.com/adamchainz/pretty-cron',
-    packages=get_packages('pretty_cron'),
+    packages=find_packages(exclude=['tests', 'tests.*']),
     include_package_data=True,
     install_requires=[],
     license="MIT",

--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,8 @@ import sys
 
 try:
     from setuptools import setup
-    from setuptools.command.test import test as TestCommand
 except ImportError:
     from distutils.core import setup
-    from distutils.command.test import test as TestCommand
 
 
 def get_version(package):
@@ -51,25 +49,6 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read().replace('.. :changelog:', '')
 
 
-class PyTest(TestCommand):
-    user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
-
-    def initialize_options(self):
-        TestCommand.initialize_options(self)
-        self.pytest_args = []
-
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        # import here, cause outside the eggs aren't loaded
-        import pytest
-        errno = pytest.main(self.pytest_args)
-        sys.exit(errno)
-
-
 setup(
     name='pretty-cron',
     version=version,
@@ -96,6 +75,4 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
     ],
-    tests_require=['pytest'],
-    cmdclass={'test': PyTest},
 )

--- a/tests/test_prettify.py
+++ b/tests/test_prettify.py
@@ -1,3 +1,6 @@
+# -*- encoding:utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 from pretty_cron import prettify_cron as pc
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,19 @@
 [tox]
-envlist = py27, pypy, py34, py35
+envlist =
+    py{27,35}-codestyle,
+    py{27,py,34,35}
 
 [testenv]
-commands = coverage run -p --source=pretty_cron setup.py test {posargs}
-deps =
-    -r{toxinidir}/requirements.txt
+setenv =
+    PYTHONDONTWRITEBYTECODE=1
+install_command = pip install --no-deps {opts} {packages}
+deps = -r{toxinidir}/requirements.txt
+commands = ./runtests.py --nolint {posargs}
+
+
+[testenv:py27-codestyle]
+commands = ./runtests.py --lintonly
+
+
+[testenv:py35-codestyle]
+commands = ./runtests.py --lintonly


### PR DESCRIPTION
Like my other projects, add linting and some support files. Then fixed any violations, the biggest of which were changing `filter` use and `unicode_literals` on all files.
